### PR TITLE
ADD JSON, NTP for MQTT Publish

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ board = az-delivery-devkit-v4
 build_flags = -llibc -lc
 lib_ldf_mode = deep
 lib_deps = 
-	https://github.com/arduino-libraries/NTPClient.git
+	https://github.com/gmag11/ESPNtpClient.git
 	https://github.com/bblanchon/ArduinoJson.git
 	https://github.com/256dpi/arduino-mqtt.git
 	https://github.com/adafruit/DHT-sensor-library.git

--- a/src/core/component.h
+++ b/src/core/component.h
@@ -4,6 +4,10 @@
 #include <Arduino.h>
 #include <functional>
 
+struct empty_unit
+{
+};
+
 template <class T> class EspComponent
 {
 public:

--- a/src/core/connection_handler.cpp
+++ b/src/core/connection_handler.cpp
@@ -5,6 +5,7 @@ void EspConnectionHandler::setup()
   EspMqttConfig mqtt_config;
   esp_mqtt_   = EspMqtt::getInstance();
   esp_config_ = EspConfig::getInstance();
+  esp_ntp_    = EspNTP::getInstance();
 
   if (esp_mqtt_ == NULL)
   {
@@ -13,6 +14,12 @@ void EspConnectionHandler::setup()
   }
 
   if (esp_config_ == NULL)
+  {
+    // TODO include error handling (e.g. write to log file)
+    return;
+  }
+
+  if (esp_ntp_ == NULL)
   {
     // TODO include error handling (e.g. write to log file)
     return;
@@ -34,6 +41,7 @@ void EspConnectionHandler::setup()
   mqtt_config.publish_topic   = esp_config_->getMqttPubTopic();
   mqtt_config.port            = esp_config_->getAwsPort();
 
+  esp_ntp_->setup(TZ_Europe_Vienna);
   esp_mqtt_->setup(&mqtt_config);
 }
 

--- a/src/core/connection_handler.h
+++ b/src/core/connection_handler.h
@@ -3,6 +3,7 @@
 
 #include "config.h"
 #include "mqtt.h"
+#include "ntp.h"
 #include "wifi.h"
 #include <Arduino.h>
 #include <WiFiClientSecure.h>
@@ -19,7 +20,9 @@ class EspConnectionHandler
 private:
   EspWifi esp_wifi_;
   EspMqtt* esp_mqtt_;
+  EspNTP* esp_ntp_;
   EspConfig* esp_config_;
+
   WiFiClientSecure tls_client_;
   bool wifi_reconnect_attempted = false;
 

--- a/src/core/json.cpp
+++ b/src/core/json.cpp
@@ -1,0 +1,22 @@
+#include "json.h"
+
+EspJson::EspJson()
+{
+  esp_config_ = EspConfig::getInstance();
+  esp_ntp_    = EspNTP::getInstance();
+}
+
+char* EspJson::serializeForSensor(float value, char* unit, char* sensor_type, char* unique_sensor_id)
+{
+  StaticJsonDocument<300> json_document;
+  char json_buffer[300];
+  json_document["MAC_ADRESS"]       = WiFi.macAddress();
+  json_document["DEVICE_NAME"]      = esp_config_->getDeviceID();
+  json_document["SENSOR_TYPE"]      = sensor_type;
+  json_document["UNIQUE_SENSOR_ID"] = unique_sensor_id;
+  json_document["VALUE"]            = value;
+  json_document["UNIT"]             = unit;
+  json_document["TIME"]             = esp_ntp_->getValue();
+  serializeJson(json_document, json_buffer);
+  return json_buffer;
+}

--- a/src/core/json.h
+++ b/src/core/json.h
@@ -1,0 +1,20 @@
+#ifndef ESP_IOT_JSON
+#define ESP_IOT_JSON
+
+#include "config.h"
+#include "ntp.h"
+#include <ArduinoJson.h>
+#include <WiFi.h>
+
+class EspJson
+{
+private:
+  EspConfig* esp_config_;
+  EspNTP* esp_ntp_;
+
+public:
+  EspJson();
+  char* serializeForSensor(float value, char* unit, char* senor_type, char* unique_sensor_id);
+};
+
+#endif

--- a/src/core/ntp.cpp
+++ b/src/core/ntp.cpp
@@ -1,0 +1,13 @@
+#include "ntp.h"
+
+EspNTP EspNTP::esp_ntp_instance;
+
+void EspNTP::setup(char* time_zone)
+{
+  NTP.setTimeZone(time_zone);
+  NTP.begin();
+}
+char* EspNTP::getValue()
+{
+  return NTP.getTimeDateString(NTP.getFirstSync());
+}

--- a/src/core/ntp.h
+++ b/src/core/ntp.h
@@ -1,0 +1,22 @@
+#ifndef ESP_IOT_NTP
+#define ESP_IOT_NTP
+
+#include "component.h"
+#include <Arduino.h>
+#include <ESPNtpClient.h>
+
+class EspNTP : public EspComponent<char*>
+{
+private:
+  static EspNTP esp_ntp_instance;
+
+public:
+  static EspNTP* getInstance()
+  {
+    return &esp_ntp_instance;
+  }
+  void setup(char* time_zone) override;
+  char* getValue();
+};
+
+#endif

--- a/src/core/physical_sensors/gas_concentration.cpp
+++ b/src/core/physical_sensors/gas_concentration.cpp
@@ -1,10 +1,11 @@
 #include "gas_concentration.h"
 
-EspGasSensor::EspGasSensor(int32_t lower_boundary, int32_t upper_boundary)
+EspGasSensor::EspGasSensor(int32_t lower_boundary, int32_t upper_boundary, char* unique_id)
 {
   this->lower_boundary_ = lower_boundary;
   this->upper_boundary_ = upper_boundary;
   this->unit_           = GAS_UNIT;
   this->sensor_type_    = GAS_SENSOR_TYPE;
   this->mqtt_topic_     = GAS_MQTT_TOPIC;
+  this->unique_id_      = unique_id;
 }

--- a/src/core/physical_sensors/gas_concentration.h
+++ b/src/core/physical_sensors/gas_concentration.h
@@ -11,7 +11,7 @@
 class EspGasSensor : public EspSensor
 {
 public:
-  EspGasSensor(int32_t lower_boundary, int32_t upper_boundary);
+  EspGasSensor(int32_t lower_boundary, int32_t upper_boundary, char* unique_id);
 };
 
 #endif

--- a/src/core/physical_sensors/humidity.cpp
+++ b/src/core/physical_sensors/humidity.cpp
@@ -1,10 +1,11 @@
 #include "humidity.h"
 
-EspHumiditySensor::EspHumiditySensor(int32_t lower_boundary, int32_t upper_boundary)
+EspHumiditySensor::EspHumiditySensor(int32_t lower_boundary, int32_t upper_boundary, char* unique_id)
 {
   this->lower_boundary_ = lower_boundary;
   this->upper_boundary_ = upper_boundary;
   this->unit_           = HUMIDITY_UNIT;
   this->sensor_type_    = HUMIDITY_SENSOR_TYPE;
   this->mqtt_topic_     = HUMIDITY_MQTT_TOPIC;
+  this->unique_id_      = unique_id;
 }

--- a/src/core/physical_sensors/humidity.h
+++ b/src/core/physical_sensors/humidity.h
@@ -11,7 +11,7 @@
 class EspHumiditySensor : public EspSensor
 {
 public:
-  EspHumiditySensor(int32_t lower_boundary, int32_t upper_boundary);
+  EspHumiditySensor(int32_t lower_boundary, int32_t upper_boundary, char* unique_id);
 };
 
 #endif

--- a/src/core/physical_sensors/illuminance.cpp
+++ b/src/core/physical_sensors/illuminance.cpp
@@ -1,10 +1,11 @@
 #include "illuminance.h"
 
-EspIlluminanceSensor::EspIlluminanceSensor(int32_t lower_boundary, int32_t upper_boundary)
+EspIlluminanceSensor::EspIlluminanceSensor(int32_t lower_boundary, int32_t upper_boundary, char* unique_id)
 {
   this->lower_boundary_ = lower_boundary;
   this->upper_boundary_ = upper_boundary;
   this->unit_           = ILLUMINANCE_UNIT;
   this->sensor_type_    = ILLUMINANCE_SENSOR_TYPE;
   this->mqtt_topic_     = ILLUMINANCE_MQTT_TOPIC;
+  this->unique_id_      = unique_id;
 }

--- a/src/core/physical_sensors/illuminance.h
+++ b/src/core/physical_sensors/illuminance.h
@@ -11,7 +11,7 @@
 class EspIlluminanceSensor : public EspSensor
 {
 public:
-  EspIlluminanceSensor(int32_t lower_boundary, int32_t upper_boundary);
+  EspIlluminanceSensor(int32_t lower_boundary, int32_t upper_boundary, char* unique_id);
 };
 
 #endif

--- a/src/core/physical_sensors/temperature.cpp
+++ b/src/core/physical_sensors/temperature.cpp
@@ -1,10 +1,11 @@
 #include "temperature.h"
 
-EspTemperatureSensor::EspTemperatureSensor(int32_t lower_boundary, int32_t upper_boundary)
+EspTemperatureSensor::EspTemperatureSensor(int32_t lower_boundary, int32_t upper_boundary, char* unique_id)
 {
   this->lower_boundary_ = lower_boundary;
   this->upper_boundary_ = upper_boundary;
   this->unit_           = TEMP_UNIT;
   this->sensor_type_    = TEMP_SENSOR_TYPE;
   this->mqtt_topic_     = TEMP_MQTT_TOPIC;
+  this->unique_id_      = unique_id;
 }

--- a/src/core/physical_sensors/temperature.h
+++ b/src/core/physical_sensors/temperature.h
@@ -4,14 +4,14 @@
 #include "../sensor.h"
 #include "Arduino.h"
 
-#define TEMP_UNIT "°C"
+#define TEMP_UNIT        "°C"
 #define TEMP_SENSOR_TYPE "temperature"
-#define TEMP_MQTT_TOPIC "/temperature"
+#define TEMP_MQTT_TOPIC  "/temperature"
 
 class EspTemperatureSensor : public EspSensor
 {
 public:
-  EspTemperatureSensor(int32_t lower_boundary, int32_t upper_boundary);
+  EspTemperatureSensor(int32_t lower_boundary, int32_t upper_boundary, char* unique_id);
 };
 
 #endif

--- a/src/core/sensor.cpp
+++ b/src/core/sensor.cpp
@@ -12,5 +12,7 @@ void EspSensor::setValue(float value)
 
 void EspSensor::updateMQTT()
 {
-  // do some mqtt stuff here
+  char* serialized_json_message =
+      this->esp_json_.serializeForSensor(this->current_value_, this->unit_, this->sensor_type_, this->unique_id_);
+  this->esp_mqtt_->publish(this->mqtt_topic_, serialized_json_message);
 }

--- a/src/core/sensor.h
+++ b/src/core/sensor.h
@@ -2,15 +2,12 @@
 #define ESP_IOT_SENSOR
 
 #include "component.h"
+#include "json.h"
 #include "mqtt.h"
 #include <Arduino.h>
 #include <string>
 
-struct unit
-{
-};
-
-class EspSensor : public EspComponent<unit>
+class EspSensor : public EspComponent<empty_unit>
 {
 protected:
   int32_t lower_boundary_;
@@ -19,7 +16,9 @@ protected:
   char* unit_;
   char* sensor_type_;
   char* mqtt_topic_;
+  char* unique_id_;
   EspMqtt* esp_mqtt_;
+  EspJson esp_json_;
 
 public:
   EspSensor();

--- a/src/sensors/DHT22/DHT22.cpp
+++ b/src/sensors/DHT22/DHT22.cpp
@@ -3,8 +3,8 @@
 void DHT22::setup(uint8_t pin)
 {
   dht22             = DHT(pin, DHT_TYPE);
-  this->temperature = EspTemperatureSensor(-50, 100);
-  this->humidity    = EspHumiditySensor(0, 100);
+  this->temperature = EspTemperatureSensor(-50, 100, "1");
+  this->humidity    = EspHumiditySensor(0, 100, "1");
   dht22.begin();
 }
 


### PR DESCRIPTION
The pull request contains an implementation of a NTP class and a JSON class. Both are essential for creating a valid MQTT message. 
In the `class EspSensor`, the function `EspJson::serialize(args)` is implemented, which takes the current measured value and pareses is into a usable char* which is in the form of a JSON object.